### PR TITLE
Feature/int api

### DIFF
--- a/iTriangle/Cargo.toml
+++ b/iTriangle/Cargo.toml
@@ -20,11 +20,7 @@ serde = ["dep:serde", "i_overlay/serde"]
 [dependencies]
 serde = { version = "^1.0", default-features = false, features = ["derive"], optional = true }
 
-#i_overlay = { path = "../../iOverlay/iOverlay" }
-#i_tree = { path = "../../iTree" }
-#i_key_sort = { path = "../../iKeySort/iKeySort" }
-
-i_overlay = "^7.0.3"
+i_overlay = { version = "^8.0.0", path = "../../iOverlay/iOverlay" }
 i_tree = "~0.19.0"
 i_key_sort = "~0.11.0"
 

--- a/iTriangle/Cargo.toml
+++ b/iTriangle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i_triangle"
-version = "0.45.2"
+version = "0.46.0"
 edition = "2021"
 authors = ["Nail Sharipov <nailxsharipov@gmail.com>"]
 description = "Polygon Triangulation Library: Efficient Delaunay Triangulation for Complex Shapes."

--- a/iTriangle/Cargo.toml
+++ b/iTriangle/Cargo.toml
@@ -20,10 +20,11 @@ serde = ["dep:serde", "i_overlay/serde"]
 [dependencies]
 serde = { version = "^1.0", default-features = false, features = ["derive"], optional = true }
 
-i_overlay = { version = "^8.0.0", path = "../../iOverlay/iOverlay" }
+i_overlay = { version = "^8.0.0"}
 i_tree = "~0.19.0"
 i_key_sort = "~0.11.0"
 
+#i_overlay = { path = "../../iOverlay/iOverlay" }
 
 
 [dev-dependencies]

--- a/iTriangle/src/advanced/centroid.rs
+++ b/iTriangle/src/advanced/centroid.rs
@@ -132,8 +132,8 @@ impl<I: IntNumber> IntTriangle<I> {
         let b = self.vertices[1].point;
         let c = self.vertices[2].point;
 
-        let x = a.x.wide() + b.x.wide() + c.x.wide();
-        let y = a.y.wide() + b.y.wide() + c.y.wide();
+        let x = a.x.to_wide() + b.x.to_wide() + c.x.to_wide();
+        let y = a.y.to_wide() + b.y.to_wide() + c.y.to_wide();
 
         IntPoint::new(
             I::from_wide(x / I::Wide::from_usize(3)),
@@ -144,8 +144,8 @@ impl<I: IntNumber> IntTriangle<I> {
 
 #[inline]
 fn middle<I: IntNumber>(a: IntPoint<I>, b: IntPoint<I>) -> IntPoint<I> {
-    let x = a.x.wide() + b.x.wide();
-    let y = a.y.wide() + b.y.wide();
+    let x = a.x.to_wide() + b.x.to_wide();
+    let y = a.y.to_wide() + b.y.to_wide();
     IntPoint::new(
         I::from_wide(x / I::Wide::TWO),
         I::from_wide(y / I::Wide::TWO),

--- a/iTriangle/src/float/custom.rs
+++ b/iTriangle/src/float/custom.rs
@@ -2,15 +2,13 @@ use crate::float::triangulation::RawTriangulation;
 use crate::int::custom::IntCustomTriangulatable;
 use crate::int::triangulation::RawIntTriangulation;
 use crate::int::validation::Validation;
-use i_key_sort::sort::key::SortKey;
+use i_overlay::core::integer::OverlayInt;
 use i_overlay::i_float::adapter::FloatPointAdapter;
 use i_overlay::i_float::float::compatible::FloatPointCompatible;
 use i_overlay::i_float::float::rect::FloatRect;
-use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_shape::base::data::{Contour, Shape};
 use i_overlay::i_shape::float::adapter::{PathToInt, ShapeToInt, ShapesToInt};
 use i_overlay::i_shape::float::rect::RectInit;
-use i_tree::{Expiration, LayoutNumber};
 
 /// A trait for triangulating float geometry with user-defined validation rules.
 ///
@@ -24,7 +22,7 @@ pub trait CustomTriangulatable<P: FloatPointCompatible> {
     /// Performs triangulation using the requested integer coordinate type.
     fn custom_triangulate_as<I>(&self, validation: Validation<I>) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey;
+        I: OverlayInt;
 
     /// Performs triangulation with Steiner points and a custom [`Validation`] config.
     fn custom_triangulate_with_steiner_points(
@@ -42,7 +40,7 @@ pub trait CustomTriangulatable<P: FloatPointCompatible> {
         validation: Validation<I>,
     ) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey;
+        I: OverlayInt;
 }
 
 impl<P> CustomTriangulatable<P> for Contour<P>
@@ -51,7 +49,7 @@ where
 {
     fn custom_triangulate_as<I>(&self, validation: Validation<I>) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_path(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);
@@ -71,7 +69,7 @@ where
         validation: Validation<I>,
     ) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_path(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);
@@ -95,7 +93,7 @@ where
 {
     fn custom_triangulate_as<I>(&self, validation: Validation<I>) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_paths(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);
@@ -115,7 +113,7 @@ where
         validation: Validation<I>,
     ) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_paths(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);
@@ -139,7 +137,7 @@ where
 {
     fn custom_triangulate_as<I>(&self, validation: Validation<I>) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_list_of_paths(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);
@@ -159,7 +157,7 @@ where
         validation: Validation<I>,
     ) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_list_of_paths(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);

--- a/iTriangle/src/float/triangulatable.rs
+++ b/iTriangle/src/float/triangulatable.rs
@@ -1,15 +1,13 @@
 use crate::float::triangulation::RawTriangulation;
 use crate::int::triangulatable::IntTriangulatable;
 use crate::int::triangulation::RawIntTriangulation;
-use i_key_sort::sort::key::SortKey;
+use i_overlay::core::integer::OverlayInt;
 use i_overlay::i_float::adapter::FloatPointAdapter;
 use i_overlay::i_float::float::compatible::FloatPointCompatible;
 use i_overlay::i_float::float::rect::FloatRect;
-use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_shape::base::data::{Contour, Shape};
 use i_overlay::i_shape::float::adapter::{PathToInt, ShapeToInt, ShapesToInt};
 use i_overlay::i_shape::float::rect::RectInit;
-use i_tree::{Expiration, LayoutNumber};
 
 /// A trait for triangulating float-based geometry with default validation.
 ///
@@ -31,7 +29,7 @@ pub trait Triangulatable<P: FloatPointCompatible> {
     /// Triangulates the shape(s) using the requested integer coordinate type.
     fn triangulate_as<I>(&self) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey;
+        I: OverlayInt;
 
     /// Triangulates the shape(s) and inserts the given Steiner points.
     ///
@@ -43,7 +41,7 @@ pub trait Triangulatable<P: FloatPointCompatible> {
     /// Triangulates the shape(s) with Steiner points using the requested integer coordinate type.
     fn triangulate_with_steiner_points_as<I>(&self, points: &[P]) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey;
+        I: OverlayInt;
 }
 
 impl<P> Triangulatable<P> for [P]
@@ -52,7 +50,7 @@ where
 {
     fn triangulate_as<I>(&self) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_path(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);
@@ -68,7 +66,7 @@ where
 
     fn triangulate_with_steiner_points_as<I>(&self, points: &[P]) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_path(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);
@@ -92,7 +90,7 @@ where
 {
     fn triangulate_as<I>(&self) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_paths(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);
@@ -108,7 +106,7 @@ where
 
     fn triangulate_with_steiner_points_as<I>(&self, points: &[P]) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_paths(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);
@@ -132,7 +130,7 @@ where
 {
     fn triangulate_as<I>(&self) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_list_of_paths(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);
@@ -148,7 +146,7 @@ where
 
     fn triangulate_with_steiner_points_as<I>(&self, points: &[P]) -> RawTriangulation<P, I>
     where
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
+        I: OverlayInt,
     {
         if let Some(rect) = FloatRect::with_list_of_paths(self) {
             let adapter = FloatPointAdapter::<P, I>::new(rect);

--- a/iTriangle/src/float/triangulation.rs
+++ b/iTriangle/src/float/triangulation.rs
@@ -5,7 +5,6 @@ use i_overlay::i_float::float::compatible::FloatPointCompatible;
 use i_overlay::i_float::float::number::FloatNumber;
 use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_shape::float::adapter::PathToFloat;
-use i_overlay::i_shape::util::reserve::Reserve;
 
 /// A triangulation result based on integer computation, with float mapping.
 ///
@@ -72,8 +71,7 @@ impl<P, N: IndexType> Triangulation<P, N> {
         P: FloatPointCompatible,
     {
         self.points.clear();
-        self.points
-            .reserve_capacity(triangulation.points.capacity());
+        self.points.reserve(triangulation.points.capacity());
         self.points
             .extend(triangulation.points.iter().map(|p| adapter.int_to_float(p)));
 

--- a/iTriangle/src/float/triangulator.rs
+++ b/iTriangle/src/float/triangulator.rs
@@ -2,18 +2,16 @@ use crate::float::triangulation::Triangulation;
 use crate::int::triangulation::{IndexType, IntTriangulation};
 use crate::int::triangulator::IntTriangulator;
 use crate::int::validation::Validation;
-use i_key_sort::sort::key::SortKey;
+use i_overlay::core::integer::OverlayInt;
 use i_overlay::core::solver::Solver;
 use i_overlay::i_float::float::compatible::FloatPointCompatible;
-use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_shape::flat::buffer::FlatContoursBuffer;
 use i_overlay::i_shape::source::resource::ShapeResource;
-use i_tree::{Expiration, LayoutNumber};
 
 /// A reusable triangulator that converts float-based shapes into triangle meshes.
 pub struct Triangulator<N = u16, I = i32>
 where
-    I: IntNumber + Expiration + LayoutNumber + SortKey,
+    I: OverlayInt,
 {
     flat_buffer: Option<FlatContoursBuffer<I>>,
     int_buffer: Option<IntTriangulation<I, N>>,
@@ -22,7 +20,7 @@ where
 
 impl<N, I> Triangulator<N, I>
 where
-    I: IntNumber + Expiration + LayoutNumber + SortKey,
+    I: OverlayInt,
     N: IndexType,
 {
     /// Enables or disables Delaunay refinement for triangulation.
@@ -73,7 +71,7 @@ where
 
 impl<N, I> Default for Triangulator<N, I>
 where
-    I: IntNumber + Expiration + LayoutNumber + SortKey,
+    I: OverlayInt,
     N: IndexType,
 {
     #[inline]
@@ -84,7 +82,7 @@ where
 
 impl<N, I> Triangulator<N, I>
 where
-    I: IntNumber + Expiration + LayoutNumber + SortKey,
+    I: OverlayInt,
     N: IndexType,
 {
     /// Performs triangulation on the provided shape resource and returns a new `Triangulation`.

--- a/iTriangle/src/int/custom.rs
+++ b/iTriangle/src/int/custom.rs
@@ -2,11 +2,10 @@ use crate::int::solver::ShapesSolver;
 use crate::int::solver::{ContourSolver, ShapeSolver};
 use crate::int::triangulation::RawIntTriangulation;
 use crate::int::validation::Validation;
-use i_key_sort::sort::key::SortKey;
+use i_overlay::core::integer::OverlayInt;
 use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_float::int::point::IntPoint;
 use i_overlay::i_shape::int::shape::{IntContour, IntShape, IntShapes};
-use i_tree::{Expiration, LayoutNumber};
 
 /// A trait for performing triangulation with custom validation settings.
 ///
@@ -29,9 +28,7 @@ pub trait IntCustomTriangulatable<I: IntNumber> {
     ) -> RawIntTriangulation<I>;
 }
 
-impl<I: IntNumber + Expiration + LayoutNumber + SortKey> IntCustomTriangulatable<I>
-    for IntContour<I>
-{
+impl<I: OverlayInt> IntCustomTriangulatable<I> for IntContour<I> {
     #[inline]
     fn custom_triangulate(&self, validation: Validation<I>) -> RawIntTriangulation<I> {
         ContourSolver::triangulate(validation, self)
@@ -47,9 +44,7 @@ impl<I: IntNumber + Expiration + LayoutNumber + SortKey> IntCustomTriangulatable
     }
 }
 
-impl<I: IntNumber + Expiration + LayoutNumber + SortKey> IntCustomTriangulatable<I>
-    for IntShape<I>
-{
+impl<I: OverlayInt> IntCustomTriangulatable<I> for IntShape<I> {
     #[inline]
     fn custom_triangulate(&self, validation: Validation<I>) -> RawIntTriangulation<I> {
         ShapeSolver::triangulate(validation, self)
@@ -65,9 +60,7 @@ impl<I: IntNumber + Expiration + LayoutNumber + SortKey> IntCustomTriangulatable
     }
 }
 
-impl<I: IntNumber + Expiration + LayoutNumber + SortKey> IntCustomTriangulatable<I>
-    for IntShapes<I>
-{
+impl<I: OverlayInt> IntCustomTriangulatable<I> for IntShapes<I> {
     #[inline]
     fn custom_triangulate(&self, validation: Validation<I>) -> RawIntTriangulation<I> {
         ShapesSolver::triangulate(validation, self)

--- a/iTriangle/src/int/earcut/earcut_64.rs
+++ b/iTriangle/src/int/earcut/earcut_64.rs
@@ -9,7 +9,6 @@ use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_float::int::number::wide_int::WideIntNumber;
 use i_overlay::i_float::int::point::IntPoint;
 use i_overlay::i_float::int::rect::IntRect;
-use i_overlay::i_shape::util::reserve::Reserve;
 
 pub(super) trait EarcutStore<I: IntNumber> {
     fn collect_triangles(&mut self, contour: &[IntPoint<I>], start: usize, bits: u64, count: u32);
@@ -38,10 +37,8 @@ impl<I: IntNumber> Earcut64<I> for [IntPoint<I>] {
     ) {
         debug_assert!(self.len() <= 64);
 
-        triangulation
-            .indices
-            .reserve_capacity(self.triangles_count(0));
         triangulation.indices.clear();
+        triangulation.indices.reserve(self.triangles_count(0));
 
         EarcutSolver::new(self, FlatEarcutStore::new(triangulation)).triangulate();
 
@@ -52,10 +49,8 @@ impl<I: IntNumber> Earcut64<I> for [IntPoint<I>] {
     fn earcut_net_triangulate_into(&self, triangulation: &mut RawIntTriangulation<I>) {
         debug_assert!(self.len() <= 64);
 
-        triangulation
-            .triangles
-            .reserve_capacity(self.triangles_count(0));
         triangulation.triangles.clear();
+        triangulation.triangles.reserve(self.triangles_count(0));
 
         EarcutSolver::new(self, NetEarcutStore::new(self.len(), triangulation)).triangulate();
 

--- a/iTriangle/src/int/monotone/chain/builder.rs
+++ b/iTriangle/src/int/monotone/chain/builder.rs
@@ -7,7 +7,6 @@ use i_overlay::i_float::int::point::IntPoint;
 use i_overlay::i_float::triangle::Triangle;
 use i_overlay::i_shape::flat::buffer::FlatContoursBuffer;
 use i_overlay::i_shape::int::shape::{IntContour, IntShape};
-use i_overlay::i_shape::util::reserve::Reserve;
 
 pub(crate) struct ChainBuilder;
 
@@ -99,8 +98,8 @@ impl<I: IntNumber> ChainVertexExport for [ChainVertex<I>] {
 
     #[inline]
     fn feed_points(&self, points: &mut Vec<IntPoint<I>>) {
-        points.reserve_capacity(self.len());
         points.clear();
+        points.reserve(self.len());
         let mut index = usize::MAX;
         for v in self.iter() {
             if v.index != index {

--- a/iTriangle/src/int/monotone/flat/triangulator.rs
+++ b/iTriangle/src/int/monotone/flat/triangulator.rs
@@ -8,7 +8,6 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_float::triangle::Triangle;
-use i_overlay::i_shape::util::reserve::Reserve;
 use i_tree::set::list::SetList;
 use i_tree::set::sort::SetCollection;
 use i_tree::set::tree::SetTree;
@@ -31,8 +30,8 @@ impl<I: IntNumber> FlatTriangulation<I> for [ChainVertex<I>] {
         triangles_count: usize,
         triangulation: &mut IntTriangulation<I, N>,
     ) {
-        triangulation.indices.reserve_capacity(triangles_count);
         triangulation.indices.clear();
+        triangulation.indices.reserve(triangles_count);
 
         let mut builder = FlatBuilder::new(triangulation);
 
@@ -227,7 +226,7 @@ impl<I: IntNumber> FlatSection<I> {
             let mut split_index = 0;
             let mut min_dist = None;
             for (i, v) in self.points.iter().enumerate() {
-                let dist = a.point.x.wide() - v.point.x.wide();
+                let dist = a.point.x.to_wide() - v.point.x.to_wide();
                 if min_dist.is_none_or(|min_dist| dist < min_dist) {
                     min_dist = Some(dist);
                     split_index = i;

--- a/iTriangle/src/int/monotone/net/triangulator.rs
+++ b/iTriangle/src/int/monotone/net/triangulator.rs
@@ -12,7 +12,6 @@ use core::cmp::Ordering;
 use core::mem::swap;
 use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_float::triangle::Triangle;
-use i_overlay::i_shape::util::reserve::Reserve;
 use i_tree::set::list::SetList;
 use i_tree::set::sort::SetCollection;
 use i_tree::set::tree::SetTree;
@@ -36,8 +35,8 @@ impl<I: IntNumber> NetTriangulation<I> for [ChainVertex<I>] {
         triangles_count: usize,
         triangulation: &mut RawIntTriangulation<I>,
     ) {
-        triangulation.triangles.reserve_capacity(triangles_count);
         triangulation.triangles.clear();
+        triangulation.triangles.reserve(triangles_count);
         let mut builder = NetBuilder::new(triangulation);
 
         let n = self.len();
@@ -309,9 +308,9 @@ impl<I: IntNumber> Section<I> {
         if i >= edges.len() {
             let last = edges[edges.len() - 1].b;
             let mut index = edges.len();
-            let mut min_dist = vp.point.x.wide() - last.point.x.wide();
+            let mut min_dist = vp.point.x.to_wide() - last.point.x.to_wide();
             for (ei, e) in edges.iter().enumerate() {
-                let dist = vp.point.x.wide() - e.a.point.x.wide();
+                let dist = vp.point.x.to_wide() - e.a.point.x.to_wide();
                 if dist < min_dist {
                     min_dist = dist;
                     index = ei;
@@ -530,9 +529,9 @@ impl<I: IntNumber> Section<I> {
         if i >= edges.len() {
             let last = edges[edges.len() - 1].b;
             let mut index = edges.len();
-            let mut min_dist = vp.point.x.wide() - last.point.x.wide();
+            let mut min_dist = vp.point.x.to_wide() - last.point.x.to_wide();
             for (ei, e) in edges.iter().enumerate() {
-                let dist = vp.point.x.wide() - e.a.point.x.wide();
+                let dist = vp.point.x.to_wide() - e.a.point.x.to_wide();
                 if dist < min_dist {
                     min_dist = dist;
                     index = ei;

--- a/iTriangle/src/int/solver.rs
+++ b/iTriangle/src/int/solver.rs
@@ -5,11 +5,12 @@ use crate::int::unchecked::IntUncheckedTriangulatable;
 use crate::int::validation::Validation;
 use alloc::vec::Vec;
 use i_key_sort::sort::key::SortKey;
+use i_overlay::core::integer::OverlayInt;
 use i_overlay::core::simplify::Simplify;
 use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_float::int::point::IntPoint;
 use i_overlay::i_shape::int::shape::{IntContour, IntShape, IntShapes};
-use i_tree::{Expiration, LayoutNumber};
+use i_tree::Expiration;
 
 pub(super) struct ShapesSolver;
 pub(super) struct ShapeSolver;
@@ -17,7 +18,7 @@ pub(super) struct ContourSolver;
 
 impl ShapesSolver {
     #[inline]
-    pub(super) fn triangulate<I: IntNumber + Expiration + LayoutNumber + SortKey>(
+    pub(super) fn triangulate<I: OverlayInt>(
         validation: Validation<I>,
         shapes: &IntShapes<I>,
     ) -> RawIntTriangulation<I> {
@@ -68,9 +69,7 @@ impl ShapesSolver {
     }
 
     #[inline]
-    pub(super) fn triangulate_with_steiner_points<
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
-    >(
+    pub(super) fn triangulate_with_steiner_points<I: OverlayInt>(
         validation: Validation<I>,
         shapes: &IntShapes<I>,
         points: &[IntPoint<I>],
@@ -133,7 +132,7 @@ impl ShapesSolver {
 
 impl ShapeSolver {
     #[inline]
-    pub(super) fn triangulate<I: IntNumber + Expiration + LayoutNumber + SortKey>(
+    pub(super) fn triangulate<I: OverlayInt>(
         validation: Validation<I>,
         shape: &IntShape<I>,
     ) -> RawIntTriangulation<I> {
@@ -151,9 +150,7 @@ impl ShapeSolver {
     }
 
     #[inline]
-    pub(super) fn triangulate_with_steiner_points<
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
-    >(
+    pub(super) fn triangulate_with_steiner_points<I: OverlayInt>(
         validation: Validation<I>,
         shape: &IntShape<I>,
         points: &[IntPoint<I>],
@@ -183,7 +180,7 @@ impl ShapeSolver {
 
 impl ContourSolver {
     #[inline]
-    pub(super) fn triangulate<I: IntNumber + Expiration + LayoutNumber + SortKey>(
+    pub(super) fn triangulate<I: OverlayInt>(
         validation: Validation<I>,
         contour: &IntContour<I>,
     ) -> RawIntTriangulation<I> {
@@ -206,9 +203,7 @@ impl ContourSolver {
     }
 
     #[inline]
-    pub(super) fn triangulate_with_steiner_points<
-        I: IntNumber + Expiration + LayoutNumber + SortKey,
-    >(
+    pub(super) fn triangulate_with_steiner_points<I: OverlayInt>(
         validation: Validation<I>,
         contour: &IntContour<I>,
         points: &[IntPoint<I>],

--- a/iTriangle/src/int/triangulatable.rs
+++ b/iTriangle/src/int/triangulatable.rs
@@ -1,10 +1,9 @@
 use crate::int::solver::{ContourSolver, ShapeSolver, ShapesSolver};
 use crate::int::triangulation::RawIntTriangulation;
-use i_key_sort::sort::key::SortKey;
+use i_overlay::core::integer::OverlayInt;
 use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_float::int::point::IntPoint;
 use i_overlay::i_shape::int::shape::{IntContour, IntShape, IntShapes};
-use i_tree::{Expiration, LayoutNumber};
 /// A trait for performing triangulation with default validation settings.
 ///
 /// Provides a simplified interface for converting shapes or contours into triangle meshes.
@@ -35,7 +34,7 @@ pub trait IntTriangulatable<I: IntNumber> {
     fn triangulate_with_steiner_points(&self, points: &[IntPoint<I>]) -> RawIntTriangulation<I>;
 }
 
-impl<I: IntNumber + Expiration + LayoutNumber + SortKey> IntTriangulatable<I> for IntContour<I> {
+impl<I: OverlayInt> IntTriangulatable<I> for IntContour<I> {
     #[inline]
     fn triangulate(&self) -> RawIntTriangulation<I> {
         ContourSolver::triangulate(Default::default(), self)
@@ -47,7 +46,7 @@ impl<I: IntNumber + Expiration + LayoutNumber + SortKey> IntTriangulatable<I> fo
     }
 }
 
-impl<I: IntNumber + Expiration + LayoutNumber + SortKey> IntTriangulatable<I> for IntShape<I> {
+impl<I: OverlayInt> IntTriangulatable<I> for IntShape<I> {
     #[inline]
     fn triangulate(&self) -> RawIntTriangulation<I> {
         ShapeSolver::triangulate(Default::default(), self)
@@ -59,7 +58,7 @@ impl<I: IntNumber + Expiration + LayoutNumber + SortKey> IntTriangulatable<I> fo
     }
 }
 
-impl<I: IntNumber + Expiration + LayoutNumber + SortKey> IntTriangulatable<I> for IntShapes<I> {
+impl<I: OverlayInt> IntTriangulatable<I> for IntShapes<I> {
     #[inline]
     fn triangulate(&self) -> RawIntTriangulation<I> {
         ShapesSolver::triangulate(Default::default(), self)

--- a/iTriangle/src/int/triangulation.rs
+++ b/iTriangle/src/int/triangulation.rs
@@ -6,7 +6,6 @@ use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_float::int::number::wide_int::WideIntNumber;
 use i_overlay::i_float::int::point::IntPoint;
 use i_overlay::i_float::triangle::Triangle;
-use i_overlay::i_shape::util::reserve::Reserve;
 
 pub trait IndexType: Copy + Clone + TryFrom<usize> + Default {
     const MAX: usize;
@@ -266,10 +265,10 @@ impl<I: IntNumber, N: IndexType> IntTriangulation<I, N> {
 
     #[inline]
     pub fn reserve_and_clear(&mut self, new_len: usize) {
-        self.points.reserve_capacity(new_len);
         self.points.clear();
-        self.indices.reserve_capacity(3 * new_len);
+        self.points.reserve(new_len);
         self.indices.clear();
+        self.indices.reserve(3 * new_len);
     }
 
     #[inline]
@@ -347,8 +346,8 @@ impl<I: IntNumber> IndicesBuilder for [IntTriangle<I>] {
         }
 
         let count = 3 * self.len();
-        indices.reserve_capacity(count);
         indices.clear();
+        indices.reserve(count);
 
         for t in self.iter() {
             let i0 = unsafe { N::try_from(t.vertices[0].index).unwrap_unchecked() };

--- a/iTriangle/src/int/triangulator.rs
+++ b/iTriangle/src/int/triangulator.rs
@@ -3,17 +3,16 @@ use crate::int::earcut::earcut_64::Earcut64;
 use crate::int::monotone::triangulator::MonotoneTriangulator;
 use crate::int::triangulation::{IndexType, IntTriangulation, RawIntTriangulation};
 use crate::int::validation::Validation;
-use i_key_sort::sort::key::SortKey;
 use i_overlay::core::fill_rule::FillRule;
+use i_overlay::core::integer::OverlayInt;
 use i_overlay::core::overlay::Overlay;
 use i_overlay::core::solver::Solver;
 use i_overlay::i_float::int::number::int::IntNumber;
 use i_overlay::i_float::int::point::IntPoint;
 use i_overlay::i_shape::flat::buffer::FlatContoursBuffer;
 use i_overlay::i_shape::int::shape::{IntContour, IntShape, IntShapes};
-use i_tree::{Expiration, LayoutNumber};
 
-pub struct IntTriangulator<I: IntNumber + Expiration + LayoutNumber + SortKey, N> {
+pub struct IntTriangulator<I: OverlayInt, N> {
     pub overlay: Overlay<I>,
     pub fill_rule: FillRule,
     pub earcut: bool,
@@ -26,7 +25,7 @@ pub struct IntTriangulator<I: IntNumber + Expiration + LayoutNumber + SortKey, N
 
 impl<I, N> IntTriangulator<I, N>
 where
-    I: IntNumber + Expiration + LayoutNumber + SortKey,
+    I: OverlayInt,
     N: IndexType,
 {
     #[inline]
@@ -46,7 +45,7 @@ where
 
 impl<I, N> Default for IntTriangulator<I, N>
 where
-    I: IntNumber + Expiration + LayoutNumber + SortKey,
+    I: OverlayInt,
     N: IndexType,
 {
     #[inline]
@@ -57,7 +56,7 @@ where
 
 impl<I, N> IntTriangulator<I, N>
 where
-    I: IntNumber + Expiration + LayoutNumber + SortKey,
+    I: OverlayInt,
     N: IndexType,
 {
     #[inline]
@@ -135,7 +134,7 @@ where
 
 impl<I, N> IntTriangulator<I, N>
 where
-    I: IntNumber + Expiration + LayoutNumber + SortKey,
+    I: OverlayInt,
     N: IndexType,
 {
     #[inline]

--- a/iTriangle/src/tessellation/circumcenter.rs
+++ b/iTriangle/src/tessellation/circumcenter.rs
@@ -234,8 +234,8 @@ impl<I: IntNumber> Abc<I> {
         let b = self.v1.vertex.point;
         let c = self.v2.vertex.point;
 
-        let x = (b.x.wide() + c.x.wide()) >> 1;
-        let y = (b.y.wide() + c.y.wide()) >> 1;
+        let x = (b.x.to_wide() + c.x.to_wide()) >> 1;
+        let y = (b.y.to_wide() + c.y.to_wide()) >> 1;
 
         IntPoint::new(I::from_wide(x), I::from_wide(y))
     }

--- a/iTriangle/src/tessellation/split.rs
+++ b/iTriangle/src/tessellation/split.rs
@@ -85,8 +85,8 @@ fn extract<I: IntNumber>(
     }
 
     if n == 2 {
-        let x = I::from_wide((a.x.wide() + b.x.wide()) / I::Wide::TWO);
-        let y = I::from_wide((a.y.wide() + b.y.wide()) / I::Wide::TWO);
+        let x = I::from_wide((a.x.to_wide() + b.x.to_wide()) / I::Wide::TWO);
+        let y = I::from_wide((a.y.to_wide() + b.y.to_wide()) / I::Wide::TWO);
 
         contour.push(IntPoint::new(x, y));
         contour.push(b);
@@ -96,8 +96,8 @@ fn extract<I: IntNumber>(
     let n_w = I::Wide::from_usize(n);
     for i in 1..n {
         let i_w = I::Wide::from_usize(i);
-        let x = I::from_wide(a.x.wide() + ab.x * i_w / n_w);
-        let y = I::from_wide(a.y.wide() + ab.y * i_w / n_w);
+        let x = I::from_wide(a.x.to_wide() + ab.x * i_w / n_w);
+        let y = I::from_wide(a.y.to_wide() + ab.y * i_w / n_w);
 
         contour.push(IntPoint::new(x, y));
     }

--- a/iTriangle/tests/float_tests.rs
+++ b/iTriangle/tests/float_tests.rs
@@ -1,20 +1,18 @@
 #[cfg(test)]
 mod tests {
-    use i_key_sort::sort::key::SortKey;
     use i_overlay::core::fill_rule::FillRule;
+    use i_overlay::core::integer::OverlayInt;
     use i_overlay::float::simplify::SimplifyShape;
-    use i_overlay::i_float::int::number::int::IntNumber;
     use i_overlay::i_shape::base::data::Contour;
     use i_overlay::i_shape::float::area::Area;
-    use i_tree::{Expiration, LayoutNumber};
     use i_triangle::float::triangulatable::Triangulatable;
     use i_triangle::float::triangulation::Triangulation;
     use i_triangle::float::triangulator::Triangulator;
     use rand::RngExt;
 
-    trait TestInt: IntNumber + Expiration + LayoutNumber + SortKey {}
+    trait TestInt: OverlayInt {}
 
-    impl<I> TestInt for I where I: IntNumber + Expiration + LayoutNumber + SortKey {}
+    impl<I: OverlayInt> TestInt for I {}
 
     #[test]
     fn test_0() {


### PR DESCRIPTION
## Summary

Updated `iTriangle` for compatibility with the latest `iFloat`, `iShape`, and `iOverlay` APIs.

- Adopted the new `OverlayInt` bound.
- Replaced `reserve_capacity` with `Vec::reserve`.
- Renamed `wide()` calls to `to_wide()`.
- Updated the dependency to `iOverlay 8.0.0`.
- Adapted tests to the new integer API.

## Validation

- `cargo check`
- `cargo test --all-features`
- `cargo clippy --lib`