### PR TITLE
advanced/delaunay: Make `IntDelaunay::into_raw` public

### DIFF
--- a/iTriangle/src/advanced/delaunay.rs
+++ b/iTriangle/src/advanced/delaunay.rs
@@ -22,8 +22,12 @@ pub struct IntDelaunay<I: IntNumber> {
 }
 
 impl<I: IntNumber> IntDelaunay<I> {
+    /// Converts a Delaunay triangulation into an int triangle mesh.
+    ///
+    /// # Returns
+    /// A new [`RawIntTriangulation`] with the same triangles.
     #[inline]
-    pub(crate) fn into_raw(self) -> RawIntTriangulation<I> {
+    pub fn into_raw(self) -> RawIntTriangulation<I> {
         RawIntTriangulation {
             triangles: self.triangles,
             points: self.points,


### PR DESCRIPTION
Given that the `RawIntTriangulation` is slightly easier to traverse, and has more versatile methods, imo this would be very useful downstream, and avoid some complications.